### PR TITLE
Validate failing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,3 +460,4 @@ pytest -sv ./tests/
   url = {https://github.com/huggingface/datatrove}
 }
 ```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ processing = [
     "inscriptis",
 #   "readability-lxml @ git+https://github.com/huggingface/python-readability.git@speedup",
     "tldextract",
-    "trafilatura>=1.8.0",
+    "trafilatura>=1.8.0,<1.12",
     "tokenizers",
     "ftfy",
     "fasteners",


### PR DESCRIPTION
```python
=========================== short test summary info ============================
FAILED tests/pipeline/test_extractors.py::TestExtractors::test_basic_article_trafilatura - AssertionError: 'Hello World!\nHello World!' != 'Hello World!'
- Hello World!
  Hello World!
======= 1 failed, 63 passed, 1 skipped, 19 warnings in 90.94s (0:01:30) ========
```

A test was failing when I was developing locally, so I created this PR to test that something had broken. Restricting `trafilatura<1.12` [(v1.12 came out last week)](https://github.com/adbar/trafilatura/releases) fixes the issue.